### PR TITLE
Fix stream closing

### DIFF
--- a/docs/rendering.rst
+++ b/docs/rendering.rst
@@ -85,7 +85,7 @@ Image Rendering
 There are two ways to get an image of the generated QR code. Both renderers 
 have a few things in common.
 
-Both renderers take a file path or writable file stream and draw the QR
+Both renderers take a file path or writable stream and draw the QR
 code there. The methods should auto-detect which is which.
 
 Each renderer takes a scale parameter. This parameter sets the size of a single
@@ -114,6 +114,11 @@ default foreground color is black.
   >>> url = pyqrcode.create('http://uca.edu')
   >>> url.svg(sys.stdout, scale=1)
   >>> url.svg('uca.svg', scale=4)
+  >>> # in-memory stream is also supported
+  >>> buffer = io.StringIO()
+  >>> url.svg(buffer)
+  >>> # do whatever you want with buffer.getvalue()
+  >>> print(list(buffer.getvalue()))
   
 You can change the colors of the data-modules using the *module_color*
 parameter. Likewise, you can specify a background using the *background*
@@ -139,6 +144,13 @@ the :py:meth:`pyqrcode.QRCode.png` method.
   >>> url = pyqrcode.create('http://uca.edu')
   >>> with open('code.png', 'w') as fstream:
   ...     url.png(fstream, scale=5)
+  >>> # same as above
+  >>> url.png('code.png', scale=5)
+  >>> # in-memory stream is also supported
+  >>> buffer = io.BytesIO()
+  >>> url.png(buffer)
+  >>> # do whatever you want with buffer.getvalue()
+  >>> print(list(buffer.getvalue()))
 
 
 Colors should be a list or tuple containing numbers between zero an 255. The

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -241,7 +241,8 @@ class QRCode:
             PNG file.
 
         This method will write the given *file* out as a PNG file. The file
-        can be either a string file path, or a writable stream.
+        can be either a string file path, or a writable stream. The file
+        will not be automatically closed if a stream is given.
 
         The *scale* parameter sets how large to draw a single module. By
         default one pixel is used to draw a single module. This may make the
@@ -280,7 +281,8 @@ class QRCode:
         are drawn with a single line.
 
         The *file* parameter is used to specify where to write the document
-        to. It can either be a writable stream or a file path.
+        to. It can either be a writable stream or a file path. The file
+        will not be automatically closed if a stream is given.
 
         The *scale* parameter sets how large to draw
         a single module. By default one pixel is used to draw a single

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -828,20 +828,28 @@ class QRCodeBuilder:
 ##############################################################################
 
 def _get_file(file, mode):
-    """This method returns the file parameter if it is an open writable
-    stream. Otherwise it treats the file parameter as a file path and
-    opens it with the given mode. It is used by the svg and png methods
-    to interpret the file parameter.
+    """This method returns a tuple containing the stream and a flag to indicate
+    if the stream should be automatically closed.
+
+    The file parameter is returned if it is an open writable stream. Otherwise.
+    it treats the file parameter as a file path and opens it with the given
+    mode.
+
+    It is used by the svg and png methods to interpret the file parameter.
+
+    :type file: str | io.BufferedIOBase
+    :type mode: str | unicode
+    :rtype: (io.BufferedIOBase, bool)
     """
     import os.path
     #See if the file parameter is a stream
     if not isinstance(file, io.IOBase):
         #If it is not a stream open a the file path
-        return open(os.path.abspath(file), mode)
+        return open(os.path.abspath(file), mode), True
     elif not file.writable():
         raise ValueError('Stream is not writable.')
     else:
-        return file
+        return file, False
 
 def _get_png_size(version, scale):
     """See: QRCode.get_png_size
@@ -981,7 +989,7 @@ def _svg(code, version, file, scale=1, module_color='black', background=None):
         return line_template.format(x1+scale, y1+scale, x2+scale, y2+scale,
                                     color, scale)
 
-    file = _get_file(file, 'w')
+    file, autoclose = _get_file(file, 'w')
 
     #Write the document header
     file.write("""<?xml version="1.0" encoding="UTF-8"?>
@@ -1050,6 +1058,9 @@ def _svg(code, version, file, scale=1, module_color='black', background=None):
 
     #Close the document
     file.write("</svg>\n")
+
+    if autoclose:
+        file.close()
 
 def _png(code, version, file, scale=1, module_color=None, background=None):
     """See: pyqrcode.QRCode.png()
@@ -1176,8 +1187,12 @@ def _png(code, version, file, scale=1, module_color=None, background=None):
     code = scale_code(code)
 
     #Write out the PNG
-    with _get_file(file, 'wb') as f:
+    f, autoclose = _get_file(file, 'wb')
+    try:
         w = png.Writer(width=size, height=size, greyscale=greyscale,
                        palette=palette, bitdepth=1)
 
         w.write(f, code)
+    finally:
+        if autoclose:
+            f.close()


### PR DESCRIPTION
* Both the `png` and `svg` methods correctly close the stream if a filename
  is given (the `svg` method was not calling `close`).
* The stream is not automatically closed if a stream is given (now it is
  possible to save the generated image in a on-memory buffer)