### PR TITLE
Optimized SVG QR Codes

### DIFF
--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -329,7 +329,6 @@ class QRCode:
                      module_color, background, xmldecl, svgns, title, svgclass,
                      lineclass, debug)
 
-
     def html5(self, file, scale=1, module_color='#000', background=None,
             title='QR Code', svgclass='pyqrcode', lineclass='pyqrline',
             debug=False):
@@ -378,9 +377,8 @@ class QRCode:
             >>> code.svg('live-organ-transplants.svg', scale=4,
                          module_color='brown', background='0xFFFFFF')
         """
-        builder._svg(self.code, self.version, file, scale,
-                     module_color, background, False, False, title, svgclass,
-                     lineclass, debug)
+        self.svg(file, scale, module_color, background, False, False, title,
+                 svgclass, lineclass, debug)
 
 
     def terminal(self, module_color='default', background='reverse'):

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -332,50 +332,10 @@ class QRCode:
     def html5(self, file, scale=1, module_color='#000', background=None,
             title='QR Code', svgclass='pyqrcode', lineclass='pyqrline',
             debug=False):
-        """This method writes the QR code out as an SVG document. The
-        code is drawn by drawing only the modules corresponding to a 1. They
-        are drawn using a line, such that contiguous modules in a row
-        are drawn with a single line.
+        """This method writes the QR code out as an SVG document without
+        an XML declaration and without the SVG namespace.
 
-        The *file* parameter is used to specify where to write the document
-        to. It can either be a writable stream or a file path.
-
-        The *scale* parameter sets how large to draw
-        a single module. By default one pixel is used to draw a single
-        module. This may make the code too small to be read efficiently.
-        Increasing the scale will make the code larger. Unlike the png() method,
-        this method will accept fractional scales (e.g. 2.5).
-
-        Note, three things are done to make the code more appropriate for
-        embedding in a HTML document. The "white" part of the code is actually
-        transparent. The code itself has a class of "pyqrcode". The lines
-        making up the QR code have a class "pyqrline". These should make the
-        code easier to style using CSS.
-
-        You can also set the colors directly using the *module_color* and
-        *background* parameters. The *module_color* parameter sets what color to
-        use for the data modules (the black part on most QR codes). The
-        *background* parameter sets what color to use for the background (the
-        white part on most QR codes). The parameters can be set to any valid
-        SVG or HTML color. If the background is set to None, then no background
-        will be drawn, i.e. the background will be transparent. Note, many color
-        combinations are unreadable by scanners, so be careful.
-
-        :param module_color: Color of the QR Code (default: ``#000`` (black))
-        :param background: Optional background color.
-        :param title: Optional title of the generated SVG document.
-        :param svgclass: The CSS class of the SVG document
-                (if set to ``None``, the SVG element won't have a class).
-        :param lineclass: The CSS class of the path element
-                (if set to ``None``, the path won't have a class).
-        :param debug: Inidicates if errors in the QR Code should be added to the
-                output (default: ``False``).
-
-        Example:
-            >>> code = pyqrcode.create('Hello. Uhh, can we have your liver?')
-            >>> code.html5('live-organ-transplants.svg', 3.6)
-            >>> code.html5('live-organ-transplants.svg', scale=4,
-                            module_color='brown', background='0xFFFFFF')
+        See `svg` for details.
         """
         self.svg(file, scale, module_color, background, False, False, title,
                  svgclass, lineclass, debug)

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -273,7 +273,9 @@ class QRCode:
         builder._png(self.code, self.version, file, scale,
                      module_color, background)
 
-    def svg(self, file, scale=1, module_color='#000000', background=None):
+    def svg(self, file, scale=1, module_color='#000', background=None,
+            xmldecl=True, title='QR Code', svgclass='pyqrcode',
+            lineclass='pyqrline', debug=False):
         """This method writes the QR code out as an SVG document. The
         code is drawn by drawing only the modules corresponding to a 1. They
         are drawn using a line, such that contiguous modules in a row
@@ -303,6 +305,18 @@ class QRCode:
         will be drawn, i.e. the background will be transparent. Note, many color
         combinations are unreadable by scanners, so be careful.
 
+        :param module_color: Color of the QR Code (default: ``#000`` (black))
+        :param background: Optional background color.
+        :param xmldecl: Inidcates if the XML declaration header should be
+                written (default: ``True``)
+        :param title: Optional title of the generated SVG document.
+        :param svgclass: The CSS class of the SVG document
+                (if set to ``None``, the SVG element won't have a class).
+        :param lineclass: The CSS class of the path element
+                (if set to ``None``, the path won't have a class).
+        :param debug: Inidicates if errors in the QR Code should be added to the
+                output (default: ``False``).
+
         Example:
             >>> code = pyqrcode.create('Hello. Uhh, can we have your liver?')
             >>> code.svg('live-organ-transplants.svg', 3.6)
@@ -310,7 +324,8 @@ class QRCode:
                          module_color='brown', background='0xFFFFFF')
         """
         builder._svg(self.code, self.version, file, scale,
-                     module_color, background)
+                     module_color, background, xmldecl, title, svgclass,
+                     lineclass, debug)
 
     def terminal(self, module_color='default', background='reverse'):
         """This method returns a string containing ASCII escape codes,

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -373,9 +373,9 @@ class QRCode:
 
         Example:
             >>> code = pyqrcode.create('Hello. Uhh, can we have your liver?')
-            >>> code.svg('live-organ-transplants.svg', 3.6)
-            >>> code.svg('live-organ-transplants.svg', scale=4,
-                         module_color='brown', background='0xFFFFFF')
+            >>> code.html5('live-organ-transplants.svg', 3.6)
+            >>> code.html5('live-organ-transplants.svg', scale=4,
+                            module_color='brown', background='0xFFFFFF')
         """
         self.svg(file, scale, module_color, background, False, False, title,
                  svgclass, lineclass, debug)

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -274,7 +274,7 @@ class QRCode:
                      module_color, background)
 
     def svg(self, file, scale=1, module_color='#000', background=None,
-            xmldecl=True, title='QR Code', svgclass='pyqrcode',
+            xmldecl=True, svgns=True, title='QR Code', svgclass='pyqrcode',
             lineclass='pyqrline', debug=False):
         """This method writes the QR code out as an SVG document. The
         code is drawn by drawing only the modules corresponding to a 1. They
@@ -328,6 +328,60 @@ class QRCode:
         builder._svg(self.code, self.version, file, scale,
                      module_color, background, xmldecl, svgns, title, svgclass,
                      lineclass, debug)
+
+
+    def html5(self, file, scale=1, module_color='#000', background=None,
+            title='QR Code', svgclass='pyqrcode', lineclass='pyqrline',
+            debug=False):
+        """This method writes the QR code out as an SVG document. The
+        code is drawn by drawing only the modules corresponding to a 1. They
+        are drawn using a line, such that contiguous modules in a row
+        are drawn with a single line.
+
+        The *file* parameter is used to specify where to write the document
+        to. It can either be a writable stream or a file path.
+
+        The *scale* parameter sets how large to draw
+        a single module. By default one pixel is used to draw a single
+        module. This may make the code too small to be read efficiently.
+        Increasing the scale will make the code larger. Unlike the png() method,
+        this method will accept fractional scales (e.g. 2.5).
+
+        Note, three things are done to make the code more appropriate for
+        embedding in a HTML document. The "white" part of the code is actually
+        transparent. The code itself has a class of "pyqrcode". The lines
+        making up the QR code have a class "pyqrline". These should make the
+        code easier to style using CSS.
+
+        You can also set the colors directly using the *module_color* and
+        *background* parameters. The *module_color* parameter sets what color to
+        use for the data modules (the black part on most QR codes). The
+        *background* parameter sets what color to use for the background (the
+        white part on most QR codes). The parameters can be set to any valid
+        SVG or HTML color. If the background is set to None, then no background
+        will be drawn, i.e. the background will be transparent. Note, many color
+        combinations are unreadable by scanners, so be careful.
+
+        :param module_color: Color of the QR Code (default: ``#000`` (black))
+        :param background: Optional background color.
+        :param title: Optional title of the generated SVG document.
+        :param svgclass: The CSS class of the SVG document
+                (if set to ``None``, the SVG element won't have a class).
+        :param lineclass: The CSS class of the path element
+                (if set to ``None``, the path won't have a class).
+        :param debug: Inidicates if errors in the QR Code should be added to the
+                output (default: ``False``).
+
+        Example:
+            >>> code = pyqrcode.create('Hello. Uhh, can we have your liver?')
+            >>> code.svg('live-organ-transplants.svg', 3.6)
+            >>> code.svg('live-organ-transplants.svg', scale=4,
+                         module_color='brown', background='0xFFFFFF')
+        """
+        builder._svg(self.code, self.version, file, scale,
+                     module_color, background, False, False, title, svgclass,
+                     lineclass, debug)
+
 
     def terminal(self, module_color='default', background='reverse'):
         """This method returns a string containing ASCII escape codes,

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -309,6 +309,8 @@ class QRCode:
         :param background: Optional background color.
         :param xmldecl: Inidcates if the XML declaration header should be
                 written (default: ``True``)
+        :param svgns: Indicates if the SVG namespace should be written
+                (default: ``True``)
         :param title: Optional title of the generated SVG document.
         :param svgclass: The CSS class of the SVG document
                 (if set to ``None``, the SVG element won't have a class).
@@ -324,7 +326,7 @@ class QRCode:
                          module_color='brown', background='0xFFFFFF')
         """
         builder._svg(self.code, self.version, file, scale,
-                     module_color, background, xmldecl, title, svgclass,
+                     module_color, background, xmldecl, svgns, title, svgclass,
                      lineclass, debug)
 
     def terminal(self, module_color='default', background='reverse'):

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -982,12 +982,12 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
             output (default: ``False``).
     """
 
-    def line(x, y, width):
-        """Returns coordinates to draw a line with the provided width.
+    def line(x, y, length):
+        """Returns coordinates to draw a line with the provided length.
         """
-        if not width:
+        if not length:
             return ''
-        return 'M{0} {1}h{2}'.format(x + scale, y + scale, width)
+        return 'M{0} {1}h{2}'.format(x + scale, y + scale, length)
 
     f = _get_file(file, 'w')
 

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -955,8 +955,10 @@ def _text(code):
 
     return buf.getvalue()
 
+
 def _svg(code, version, file, scale=1, module_color='#000', background=None,
-         xmldecl=True, title=None, svgclass='pyqrcode', lineclass='pyqrline',
+         xmldecl=True, svgns=True, title=None, svgclass='pyqrcode',
+         lineclass='pyqrline',
          debug=False):
     """This method writes the QR code out as an SVG document. The
     code is drawn by drawing only the modules corresponding to a 1. They
@@ -972,6 +974,8 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
     :param module_color: Color of the QR Code (default: ``#000`` (black))
     :param background: Optional background color.
     :param xmldecl: Inidcates if the XML declaration header should be written
+            (default: ``True``)
+    :param svgns: Indicates if the SVG namespace should be written
             (default: ``True``)
     :param title: Optional title of the generated SVG document.
     :param svgclass: The CSS class of the SVG document
@@ -990,12 +994,12 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
         return 'M{0} {1}h{2}'.format(x + scale, y + scale, length)
 
     f = _get_file(file, 'w')
-
     # Write the document header
     if xmldecl:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-    f.write('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {0} {0}"'
-            .format((tables.version_size[version]*scale)+(2*scale)))
+    f.write('<svg {0}viewBox="0 0 {1} {1}"'
+            .format(('xmlns="http://www.w3.org/2000/svg" ' if svgns else ''),
+                    (tables.version_size[version]*scale)+(2*scale)))
     if svgclass is not None:
         f.write(' class="{}"'.format(svgclass))
     f.write('>')
@@ -1007,7 +1011,6 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
         f.write('<rect width="{0}" height="{0}" fill="{1}" stroke-width="0"/>'
                 .format((tables.version_size[version]*scale)+(2*scale),
                         background))
-
     f.write('<path')
     if scale != 1:  # SVG default value: stroke-width = 1
         f.write(' stroke-width="{}"'.format(scale))
@@ -1016,16 +1019,12 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
     if lineclass is not None:
         f.write(' class="{}"'.format(lineclass))
     f.write(' d="')
-
     # Used to keep track of unknown/error coordinates.
     debug_path = ''
-
     # This will hold the current row number
     rnumber = 0
-
     # Keeps track of the last read bit
     last_bit = 1
-
     # Loop through each row of the code
     for row in code:
         colnumber = 0  # Reset column number
@@ -1047,15 +1046,14 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
         f.write(coord)
         # Set row number
         rnumber += scale
-
     # Close path
     f.write('"/>')
     if debug and debug_path:
         f.write('<path class="pyqrerr" stroke-width="{0}" stroke="red" d="{1}"/>'
                 .format(scale, debug_path))
-
     # Close document
     f.write('</svg>\n')
+
 
 def _png(code, version, file, scale=1, module_color=None, background=None):
     """See: pyqrcode.QRCode.png()

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -1038,9 +1038,9 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
                     coord += line(start_column, rnumber, colnumber - start_column)
                 last_bit = bit
                 start_column = colnumber
-                if debug and last_bit not in (0, 1):
-                    debug_path += line(start_column, rnumber, scale)
             colnumber += scale
+            if debug and last_bit not in (0, 1):
+                debug_path += line(colnumber - scale, rnumber, scale)
         # Add trailing bit iff it's not the background
         if last_bit == 1:
             coord += line(start_column, rnumber, colnumber - start_column)

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -1038,9 +1038,9 @@ def _svg(code, version, file, scale=1, module_color='#000', background=None,
                     coord += line(start_column, rnumber, colnumber - start_column)
                 last_bit = bit
                 start_column = colnumber
-            colnumber += scale
             if debug and last_bit not in (0, 1):
-                debug_path += line(colnumber - scale, rnumber, scale)
+                debug_path += line(colnumber, rnumber, scale)
+            colnumber += scale
         # Add trailing bit iff it's not the background
         if last_bit == 1:
             coord += line(start_column, rnumber, colnumber - start_column)


### PR DESCRIPTION
This commit adds more options to the ``svg`` method (i.e. omit XML declaration, custom CSS class definitions etc.). Further, it does not draw many ``<line>``s but one ``<path>`` element.

Caution: The output does not use the SVG height/width attributes anymore but a ``viewBox``. IMO this is preferable since the QR code could be embedded in different (HTML) environments and defines its height/width automatically.
