### PR TITLE
Added option to specify the border of text output

### DIFF
--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -353,15 +353,19 @@ class QRCode:
         """
         return builder._terminal(self.code, module_color, background)
 
-    def text(self):
+    def text(self, border=4):
         """This method returns a string based representation of the QR code.
         The data modules are represented by 1's and the background modules are
         represented by 0's. The main purpose of this method is to allow a user
         to write their own renderer.
+
+        :param border: Border around the QR code (also known as quiet zone)
+                (default: ``4``). Set to zero (``0``) if the code shouldn't
+                have a border.
 
         Example:
             >>> code = pyqrcode.create('Example')
             >>> text = code.text()
             >>> print(text)
         """
-        return builder._text(self.code)
+        return builder._text(self.code, border)

--- a/pyqrcode/__init__.py
+++ b/pyqrcode/__init__.py
@@ -353,19 +353,27 @@ class QRCode:
         """
         return builder._terminal(self.code, module_color, background)
 
-    def text(self, border=4):
+    def text(self, module_color='1', background='0', border=4, debug=True):
         """This method returns a string based representation of the QR code.
         The data modules are represented by 1's and the background modules are
         represented by 0's. The main purpose of this method is to allow a user
         to write their own renderer.
 
+        :param module_color: The character to use for the QR code modules
+                (default: "1")
+        :param background: The character to use for the QR code background
+                (default: "0").
         :param border: Border around the QR code (also known as quiet zone)
                 (default: ``4``). Set to zero (``0``) if the code shouldn't
                 have a border.
+        :param debug: Inidicates if errors in the QR code should be added (as
+                empty space modules) to the output (default: ``True``).
+                Note, that errors will be invisible if background is set to
+                ``' '``.
 
         Example:
             >>> code = pyqrcode.create('Example')
             >>> text = code.text()
             >>> print(text)
         """
-        return builder._text(self.code, border)
+        return builder._text(self.code, module_color, background, border, debug)

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -929,30 +929,35 @@ def _terminal(code, module_color='default', background='reverse'):
     return buf.getvalue()
 
 
-def _text(code, border=4):
+def _text(code, module_color='1', background='0', border=4, debug=True):
     """This method returns a text based representation of the QR code.
     This is useful for debugging purposes.
 
+    :param module_color: The character to use for the QR code modules
+            (default: "1")
+    :param background: The character to use for the QR code background
+            (default: "0").
     :param border: Border around the QR code (also known as quiet zone)
             (default: ``4``). Set to zero (``0``) if the code shouldn't
             have a border.
+    :param debug: Inidicates if errors in the QR code should be added (as
+            empty space modules) to the output (default: ``True``).
+            Note, that errors will be invisible if background is set to ``' '``.
     """
     buf = io.StringIO()
 
-    border_row = '\n'.join(['0' * (len(code[0]) + border * 2)] * border)
-    border_module = '0' * border
+    border_row = '\n'.join([background * (len(code[0]) + border * 2)] * border)
+    border_module = background * border
+
+    # Lookup table for the "colors"
+    colors = (background, module_color, ' ' if debug else module_color)
 
     buf.write(border_row)
     buf.write('\n')
     for row in code:
         buf.write(border_module)
         for bit in row:
-            if bit in (0, 1):
-                buf.write('{0}'.format(bit))
-            else:
-                # This is for debugging unfinished QR codes,
-                # unset pixels will be spaces.
-                buf.write(' ')
+            buf.write(colors[bit if bit in (0, 1) else 2])
         buf.write('{0}\n'.format(border_module))
     buf.write(border_row)
     return buf.getvalue()

--- a/pyqrcode/builder.py
+++ b/pyqrcode/builder.py
@@ -928,32 +928,35 @@ def _terminal(code, module_color='default', background='reverse'):
 
     return buf.getvalue()
 
-def _text(code):
+
+def _text(code, border=4):
     """This method returns a text based representation of the QR code.
     This is useful for debugging purposes.
+
+    :param border: Border around the QR code (also known as quiet zone)
+            (default: ``4``). Set to zero (``0``) if the code shouldn't
+            have a border.
     """
     buf = io.StringIO()
 
-    border_row = '0' * (len(code[0]) + 2)
+    border_row = '\n'.join(['0' * (len(code[0]) + border * 2)] * border)
+    border_module = '0' * border
 
     buf.write(border_row)
     buf.write('\n')
     for row in code:
-        buf.write('0')
+        buf.write(border_module)
         for bit in row:
-            if bit == 1:
-                buf.write('1')
-            elif bit == 0:
-                buf.write('0')
-            #This is for debugging unfinished QR codes,
-            #unset pixels will be spaces.
+            if bit in (0, 1):
+                buf.write('{0}'.format(bit))
             else:
+                # This is for debugging unfinished QR codes,
+                # unset pixels will be spaces.
                 buf.write(' ')
-        buf.write('0\n')
-
+        buf.write('{0}\n'.format(border_module))
     buf.write(border_row)
-
     return buf.getvalue()
+
 
 def _svg(code, version, file, scale=1, module_color='black', background=None):
     """This method writes the QR code out as an SVG document. The


### PR DESCRIPTION
Added option to specify the quiet zone for the text output. 
Note, that the default border has changed from ``1`` to ``4`` (recommended).

Set the default border value to ``1`` to make this change backward compatible